### PR TITLE
fix(docs): add better highlight for warning and danger text boxes

### DIFF
--- a/docs/src/css/app.sass
+++ b/docs/src/css/app.sass
@@ -54,6 +54,16 @@ body.body--dark
     background-color: #9cedaf
     color: #000
 
+  .doc-note--warning .doc-token
+    border: 1px dotted $dark-text-color
+    background-color: #f6f5a6
+    color: #000
+  
+  .doc-note--danger .doc-token
+    border: 1px dotted $dark-text-color
+    background-color: #f8b1b1
+    color: #000
+
   .doc-token
     border: 1px dotted $dark-text-color
     background-color: $darkest-background


### PR DESCRIPTION
Adds correction for warning and danger text box highlighting (backticking)

Scott
