### PR TITLE
fix: bug when building search index

### DIFF
--- a/docs/build/search/index.js
+++ b/docs/build/search/index.js
@@ -229,6 +229,14 @@ const processPage = (page, entry, entries) => {
   processMarkdown(ast, entries, entryItem)
 }
 
+// Some of these paths do not have a corresponding .md file OR their .md files
+// are in locations which do not follow the usual folder/file pattern
+const CUSTOM_PATHS = {
+  '/vue-components/grid': undefined,
+  '/start/roadmap': '../../../ROADMAP.md',
+  docs: undefined
+}
+
 // process child entries from menu.json
 const processChildren = (parent, entry, entries) => {
   if (parent.children) {
@@ -248,10 +256,9 @@ const processChildren = (parent, entry, entries) => {
           processChildren(menuItem, entryChild, entries)
         }
         else {
-          // roadmap is loaded from /ROADME.md unlike the others
-          // which are all loaded from /docs/src/pages
-          if (entryChild.url === '/start/roadmap') {
-            processPage('../../ROADMAP.md', entryChild, entries)
+          if (CUSTOM_PATHS.hasOwnProperty(entryChild.url)) {
+            CUSTOM_PATHS[ entryChild.url ] !== undefined &&
+            processPage(CUSTOM_PATHS[ entryChild.url ], entryChild, entries)
           }
           else {
             processPage(intro + entryChild.url + '.md', entryChild, entries)
@@ -268,7 +275,7 @@ const processMenuItem = (menuItem, entries) => {
     url: '/' + menuItem.path
   })
 
-  if (menuItem.external !== true) {
+  if (menuItem.external !== true && !CUSTOM_PATHS.hasOwnProperty(menuItem.path)) {
     if (menuItem.children) {
       const entryChild = {
         ...entryItem,

--- a/docs/build/search/index.js
+++ b/docs/build/search/index.js
@@ -229,13 +229,9 @@ const processPage = (page, entry, entries) => {
   processMarkdown(ast, entries, entryItem)
 }
 
-// Some of these paths do not have a corresponding .md file OR their .md files
-// are in locations which do not follow the usual folder/file pattern
-const CUSTOM_PATHS = {
-  '/vue-components/grid': undefined,
-  '/start/roadmap': '../../../ROADMAP.md',
-  docs: undefined
-}
+// The corresponding files for these paths are in locations which do
+// not follow the usual folder/file pattern and are not .md files like the others
+const CUSTOM_PATHS = [ '/vue-components/grid', 'docs' ]
 
 // process child entries from menu.json
 const processChildren = (parent, entry, entries) => {
@@ -255,14 +251,8 @@ const processChildren = (parent, entry, entries) => {
         if (menuItem.children) {
           processChildren(menuItem, entryChild, entries)
         }
-        else {
-          if (CUSTOM_PATHS.hasOwnProperty(entryChild.url)) {
-            CUSTOM_PATHS[ entryChild.url ] !== undefined &&
-            processPage(CUSTOM_PATHS[ entryChild.url ], entryChild, entries)
-          }
-          else {
-            processPage(intro + entryChild.url + '.md', entryChild, entries)
-          }
+        else if (!CUSTOM_PATHS.includes(entryChild.url)) {
+          processPage(intro + entryChild.url + '.md', entryChild, entries)
         }
       }
     })
@@ -275,7 +265,7 @@ const processMenuItem = (menuItem, entries) => {
     url: '/' + menuItem.path
   })
 
-  if (menuItem.external !== true && !CUSTOM_PATHS.hasOwnProperty(menuItem.path)) {
+  if (menuItem.external !== true && !CUSTOM_PATHS.includes(menuItem.path)) {
     if (menuItem.children) {
       const entryChild = {
         ...entryItem,

--- a/docs/src/assets/header/nav-items.js
+++ b/docs/src/assets/header/nav-items.js
@@ -227,7 +227,7 @@ export const expandedHeaderSecondaryToolbarNavItems = [
   },
   {
     label: 'Roadmap',
-    path: 'start/roadmap'
+    href: 'https://roadmap.quasar.dev/'
   },
   {
     label: 'Video Tutorials',

--- a/docs/src/assets/menu.json
+++ b/docs/src/assets/menu.json
@@ -95,7 +95,8 @@
       },
       {
         "name": "Roadmap",
-        "path": "roadmap"
+        "path": "https://roadmap.quasar.dev/",
+        "external": true
       },
       {
         "name": "Upgrade guide",

--- a/docs/src/router/routes.js
+++ b/docs/src/router/routes.js
@@ -17,18 +17,6 @@ const docsPages = [
     path: 'integrations',
     name: 'integrations',
     component: () => import('../pages/Integrations.vue')
-  },
-  {
-    // construct route for roadmap, it doesn't look like the other .mds, e.g: has no title
-    path: '/start/roadmap',
-    props: {
-      title: 'What\'s next?',
-      metaDesc: 'What\'s next for the Quasar Framework?',
-      editPagePath: 'ROADMAP.md',
-      metaTitle: 'Quasar Roadmap'
-    },
-    // importing from ../../../ROADMAP.md throws an error as vite is unable to find vue dependency
-    component: () => import('https://roadmap.quasar.dev/')
   }
 ]
 

--- a/docs/src/router/routes.js
+++ b/docs/src/router/routes.js
@@ -27,7 +27,8 @@ const docsPages = [
       editPagePath: 'ROADMAP.md',
       metaTitle: 'Quasar Roadmap'
     },
-    component: () => import('../../../ROADMAP.md')
+    // importing from ../../../ROADMAP.md throws an error as vite is unable to find vue dependency
+    component: () => import('https://roadmap.quasar.dev/')
   }
 ]
 


### PR DESCRIPTION
When building the search indices (`yarn build`), you get an error that says file `docs.md`, `grid.md` could not be found. This happens because the docs page corresponds to `src/Homepage.vue` (is a NOT a `.md` file) and unlike the other `.md` pages is not found in the location the parser would expect. The parser which builds the search index expects to find a markdown file called `docs.md` in the pages folder and similarly, it expects to find `grid.md` in `pages/vue-components/grid.md` which is rather found in `pages/ComponentsPage.vue`. 

This PR handles these edge cases.